### PR TITLE
Turn response_handler into FnMut

### DIFF
--- a/examples/fastcall.rs
+++ b/examples/fastcall.rs
@@ -7,52 +7,62 @@ use std::net::{SocketAddr, TcpStream};
 use std::process;
 use std::sync::Arc;
 
-use clap::{App, Arg, ArgMatches, crate_version, value_t};
+use clap::{crate_version, value_t, App, Arg, ArgMatches};
 use serde_json::Value;
 
-use rust_fast::protocol::FastMessage;
 use rust_fast::client;
-
+use rust_fast::protocol::FastMessage;
 
 static APP: &'static str = "fastcall";
 static DEFAULT_HOST: &'static str = "127.0.0.1";
 const DEFAULT_PORT: u32 = 2030;
 
-
 pub fn parse_opts<'a, 'b>(app: String) -> ArgMatches<'a> {
     App::new(app)
         .about("Command-line tool for making a node-fast RPC method call")
         .version(crate_version!())
-        .arg(Arg::with_name("host")
-             .help("DNS name or IP address for remote server")
-             .long("host")
-             .short("h")
-             .takes_value(true)
-             .required(false))
-        .arg(Arg::with_name("port")
-             .help("TCP port for remote server (Default: 2030)")
-             .long("port")
-             .short("p")
-             .takes_value(true))
-        .arg(Arg::with_name("method")
-             .help("Name of remote RPC method call")
-             .long("method")
-             .short("m")
-             .takes_value(true)
-             .required(true))
-        .arg(Arg::with_name("args")
-             .help("JSON-encoded arguments for RPC method call")
-             .long("args")
-             .takes_value(true)
-             .required(true))
-        .arg(Arg::with_name("abandon")
-             .long("abandon-immediately")
-             .short("a")
-             .takes_value(false))
-        .arg(Arg::with_name("leave_open")
-             .long("leave-conn-open")
-             .short("c")
-             .takes_value(false))
+        .arg(
+            Arg::with_name("host")
+                .help("DNS name or IP address for remote server")
+                .long("host")
+                .short("h")
+                .takes_value(true)
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("port")
+                .help("TCP port for remote server (Default: 2030)")
+                .long("port")
+                .short("p")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("method")
+                .help("Name of remote RPC method call")
+                .long("method")
+                .short("m")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("args")
+                .help("JSON-encoded arguments for RPC method call")
+                .long("args")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("abandon")
+                .long("abandon-immediately")
+                .short("a")
+                .takes_value(false),
+        )
+        .arg(
+            Arg::with_name("leave_open")
+                .long("leave-conn-open")
+                .short("c")
+                .takes_value(false),
+        )
         .get_matches()
 }
 
@@ -62,14 +72,12 @@ fn stdout_handler(msg: &FastMessage) {
 
 fn response_handler(msg: &FastMessage) -> Result<(), Error> {
     match msg.data.m.name.as_str() {
-        "date" | "echo" | "yes" |
-        "getobject" | "putobject" => stdout_handler(msg),
-        _      =>  println!("Received {} response", msg.data.m.name)
+        "date" | "echo" | "yes" | "getobject" | "putobject" => stdout_handler(msg),
+        _ => println!("Received {} response", msg.data.m.name),
     }
 
     Ok(())
 }
-
 
 fn main() {
     let matches = parse_opts(APP.to_string());
@@ -79,25 +87,26 @@ fn main() {
         .concat()
         .parse::<SocketAddr>()
         .unwrap_or_else(|e| {
-            eprintln!("Failed to parse host and port as valid socket address: \
-                       {}", e);
+            eprintln!(
+                "Failed to parse host and port as valid socket address: \
+                 {}",
+                e
+            );
             process::exit(1)
         });
     let method = String::from(matches.value_of("method").unwrap_or_else(|| {
         eprintln!("Failed to parse method argument as String");
         process::exit(1)
     }));
-    let args = value_t!(matches, "args", Value)
-        .unwrap_or_else(|e| e.exit());
+    let args = value_t!(matches, "args", Value).unwrap_or_else(|e| e.exit());
 
     let mut stream = TcpStream::connect(&addr).unwrap_or_else(|e| {
         eprintln!("Failed to connect to server: {}", e);
         process::exit(1)
     });
 
-    let result = client::send(method, args, &mut stream).and_then(|_bytes_written| {
-        client::receive(&mut stream, Arc::new(response_handler))
-    });
+    let result = client::send(method, args, &mut stream)
+        .and_then(|_bytes_written| client::receive(&mut stream, Arc::new(response_handler)));
 
     if let Err(e) = result {
         eprintln!("Error: {}", e);

--- a/examples/fastcall.rs
+++ b/examples/fastcall.rs
@@ -5,7 +5,6 @@
 use std::io::Error;
 use std::net::{SocketAddr, TcpStream};
 use std::process;
-use std::sync::Arc;
 
 use clap::{crate_version, value_t, App, Arg, ArgMatches};
 use serde_json::Value;
@@ -106,7 +105,7 @@ fn main() {
     });
 
     let result = client::send(method, args, &mut stream)
-        .and_then(|_bytes_written| client::receive(&mut stream, Arc::new(response_handler)));
+        .and_then(|_bytes_written| client::receive(&mut stream, response_handler));
 
     if let Err(e) = result {
         eprintln!("Error: {}", e);

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,8 +3,8 @@
  */
 
 use std::io::{Error, ErrorKind};
-use std::sync::Arc;
 use std::net::TcpStream;
+use std::sync::Arc;
 
 use bytes::BytesMut;
 use serde_json::Value;
@@ -16,26 +16,23 @@ use crate::protocol::{FastMessage, FastMessageData, FastMessageStatus, FastParse
 enum BufferAction {
     Keep,
     Trim(usize),
-    Done
+    Done,
 }
 
-pub fn send(method: String,
-            args: Value,
-            stream: &mut TcpStream) -> Result<usize, Error>
-{
+pub fn send(method: String, args: Value, stream: &mut TcpStream) -> Result<usize, Error> {
     //TODO: Replace hardcoded msg id
     let msg = FastMessage::data(0x1, FastMessageData::new(method, args));
     let mut write_buf = BytesMut::new();
     match protocol::encode_msg(&msg, &mut write_buf) {
         Ok(_) => stream.write(write_buf.as_ref()),
-        Err(err_str) => Err(Error::new(ErrorKind::Other, err_str))
+        Err(err_str) => Err(Error::new(ErrorKind::Other, err_str)),
     }
 }
 
-pub fn receive(stream: &mut TcpStream,
-               response_handler: Arc<(Fn(&FastMessage) -> Result<(), Error>)>)
-               -> Result<usize, Error>
-{
+pub fn receive(
+    stream: &mut TcpStream,
+    response_handler: Arc<(Fn(&FastMessage) -> Result<(), Error>)>,
+) -> Result<usize, Error> {
     let mut stream_end = false;
     let mut msg_buf: Vec<u8> = Vec::new();
     let mut total_bytes = 0;
@@ -54,14 +51,14 @@ pub fn receive(stream: &mut TcpStream,
                         msg_buf.rotate_left(rest_offset);
                         msg_buf.truncate(truncate_bytes);
                         result = Ok(total_bytes);
-                    },
+                    }
                     Ok(BufferAction::Done) => stream_end = true,
                     Err(e) => {
                         result = Err(e);
                         stream_end = true
                     }
                 }
-            },
+            }
             Err(err) => {
                 result = Err(err);
                 stream_end = true
@@ -71,10 +68,10 @@ pub fn receive(stream: &mut TcpStream,
     result
 }
 
-fn parse_and_handle_messages(read_buf: &[u8],
-                             response_handler: Arc<(Fn(&FastMessage) -> Result<(), Error>)>)
-                             -> Result<BufferAction, Error>
-{
+fn parse_and_handle_messages(
+    read_buf: &[u8],
+    response_handler: Arc<(Fn(&FastMessage) -> Result<(), Error>)>,
+) -> Result<BufferAction, Error> {
     let mut offset = 0;
     let mut done = false;
 
@@ -85,15 +82,15 @@ fn parse_and_handle_messages(read_buf: &[u8],
             Ok(ref fm) if fm.status == FastMessageStatus::End => {
                 result = Ok(BufferAction::Done);
                 done = true;
-            },
+            }
             Ok(fm) => {
                 offset += fm.msg_size.unwrap();
                 let _ = response_handler(&fm);
                 result = Ok(BufferAction::Trim(offset));
-            },
+            }
             Err(FastParseError::NotEnoughBytes(_bytes)) => {
                 done = true;
-            },
+            }
             Err(FastParseError::IOError(e)) => {
                 result = Err(e);
                 done = true;

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,25 +5,26 @@
 use std::io::{Error, ErrorKind};
 use std::sync::Arc;
 
-use slog::{Logger, debug, error};
+use slog::{debug, error, Logger};
 use tokio;
+use tokio::codec::Decoder;
 use tokio::net::TcpStream;
 use tokio::prelude::*;
-use tokio::codec::Decoder;
 
-use crate::protocol::{FastRpc, FastMessage};
+use crate::protocol::{FastMessage, FastRpc};
 
-
-pub fn process(socket: TcpStream,
-               response_handler: Arc<(Fn(&FastMessage, &Logger) -> Result<Vec<FastMessage>, Error> + Send + Sync)>,
-               log: &Logger
-)
-{
+pub fn process(
+    socket: TcpStream,
+    response_handler: Arc<
+        (Fn(&FastMessage, &Logger) -> Result<Vec<FastMessage>, Error> + Send + Sync),
+    >,
+    log: &Logger,
+) {
     let (tx, rx) = FastRpc.framed(socket).split();
     let rx_log = log.clone();
     let tx_log = log.clone();
-    let task = tx.send_all(rx.and_then(
-        move |x| {
+    let task = tx
+        .send_all(rx.and_then(move |x| {
             debug!(rx_log, "processing fast message");
             let c = Arc::clone(&response_handler);
             respond(x, c, &rx_log)
@@ -42,25 +43,26 @@ pub fn process(socket: TcpStream,
     tokio::spawn(task);
 }
 
-pub fn respond(msgs: Vec<FastMessage>,
-               response_handler: Arc<(Fn(&FastMessage, &Logger) -> Result<Vec<FastMessage>, Error> + Sync + Send)>,
-               log: &Logger)
-               -> impl Future<Item = Vec<FastMessage>, Error = Error> + Send
-{
+pub fn respond(
+    msgs: Vec<FastMessage>,
+    response_handler: Arc<
+        (Fn(&FastMessage, &Logger) -> Result<Vec<FastMessage>, Error> + Sync + Send),
+    >,
+    log: &Logger,
+) -> impl Future<Item = Vec<FastMessage>, Error = Error> + Send {
     match msgs.get(0) {
-        Some(msg) => {
-            match response_handler(msg, &log) {
-                Ok(mut response) => {
-                    debug!(log, "generated response");
-                    let method = msg.data.m.name.clone();
-                    response.push(FastMessage::end(msg.id, method));
-                    Box::new(future::ok(response))
-                },
-                Err(err) => Box::new(future::err(err))
+        Some(msg) => match response_handler(msg, &log) {
+            Ok(mut response) => {
+                debug!(log, "generated response");
+                let method = msg.data.m.name.clone();
+                response.push(FastMessage::end(msg.id, method));
+                Box::new(future::ok(response))
             }
+            Err(err) => Box::new(future::err(err)),
         },
-        None => {
-            Box::new(future::err(Error::new(ErrorKind::Other, "no message available")))
-        }
+        None => Box::new(future::err(Error::new(
+            ErrorKind::Other,
+            "no message available",
+        ))),
     }
 }

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -6,18 +6,19 @@ use std::sync::{Arc, Barrier, Mutex};
 use std::thread;
 
 use serde_json::Value;
-use slog::{Drain, Logger, debug, error, info, o};
+use slog::{debug, error, info, o, Drain, Logger};
 use tokio::net::TcpListener;
 use tokio::prelude::*;
 
-use rust_fast::protocol::{FastMessage};
 use rust_fast::client;
+use rust_fast::protocol::FastMessage;
 use rust_fast::server;
 
-
-fn echo_handler(msg: &FastMessage,
-                mut response: Vec<FastMessage>,
-                log: &Logger) -> Result<Vec<FastMessage>, Error> {
+fn echo_handler(
+    msg: &FastMessage,
+    mut response: Vec<FastMessage>,
+    log: &Logger,
+) -> Result<Vec<FastMessage>, Error> {
     debug!(log, "handling echo function request");
     response.push(FastMessage::data(msg.id, msg.data.clone()));
     Ok(response)
@@ -28,17 +29,18 @@ fn msg_handler(msg: &FastMessage, log: &Logger) -> Result<Vec<FastMessage>, Erro
 
     match msg.data.m.name.as_str() {
         "echo" => echo_handler(msg, response, &log),
-        _ => Err(Error::new(ErrorKind::Other, format!("Unsupport functon: {}", msg.data.m.name)))
+        _ => Err(Error::new(
+            ErrorKind::Other,
+            format!("Unsupport functon: {}", msg.data.m.name),
+        )),
     }
 }
 
 fn run_server(barrier: Arc<Barrier>) {
     let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
     let root_log = Logger::root(
-        Mutex::new(
-            slog_term::FullFormat::new(plain).build()
-        ).fuse(),
-        o!("build-id" => "0.1.0")
+        Mutex::new(slog_term::FullFormat::new(plain).build()).fuse(),
+        o!("build-id" => "0.1.0"),
     );
 
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:56655".to_string());
@@ -52,15 +54,13 @@ fn run_server(barrier: Arc<Barrier>) {
     tokio::run({
         let process_log = root_log.clone();
         let err_log = root_log.clone();
-        listener.incoming()
-            .map_err(move |e| {
-                error!(&err_log, "failed to accept socket"; "err" => %e)
+        listener
+            .incoming()
+            .map_err(move |e| error!(&err_log, "failed to accept socket"; "err" => %e))
+            .for_each(move |socket| {
+                server::process(socket, Arc::new(msg_handler), &process_log);
+                Ok(())
             })
-            .for_each(
-                move |socket| {
-                    server::process(socket, Arc::new(msg_handler), &process_log);
-                    Ok(())
-                })
     });
 }
 
@@ -73,9 +73,8 @@ fn assert_handler(msg: &FastMessage) {
 
 fn response_handler(msg: &FastMessage) -> Result<(), Error> {
     match msg.data.m.name.as_str() {
-        "date" | "echo" | "yes" |
-        "getobject" | "putobject" => assert_handler(msg),
-        _      =>  println!("Received {} response", msg.data.m.name)
+        "date" | "echo" | "yes" | "getobject" | "putobject" => assert_handler(msg),
+        _ => println!("Received {} response", msg.data.m.name),
     }
 
     Ok(())
@@ -92,7 +91,7 @@ fn client_server_comms() {
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:56655".to_string());
     let addr = addr.parse::<SocketAddr>().unwrap();
 
-   let mut stream = TcpStream::connect(&addr).unwrap_or_else(|e| {
+    let mut stream = TcpStream::connect(&addr).unwrap_or_else(|e| {
         eprintln!("Failed to connect to server: {}", e);
         process::exit(1)
     });
@@ -100,9 +99,8 @@ fn client_server_comms() {
     let method = String::from("echo");
     let args_str = "[\"abc\"]";
     let args: Value = serde_json::from_str(args_str).unwrap();
-    let _result = client::send(method, args, &mut stream).and_then(|_bytes_written| {
-        client::receive(&mut stream, Arc::new(response_handler))
-    });
+    let _result = client::send(method, args, &mut stream)
+        .and_then(|_bytes_written| client::receive(&mut stream, Arc::new(response_handler)));
 
     assert!(true);
 }

--- a/tests/client_server_test.rs
+++ b/tests/client_server_test.rs
@@ -100,7 +100,7 @@ fn client_server_comms() {
     let args_str = "[\"abc\"]";
     let args: Value = serde_json::from_str(args_str).unwrap();
     let _result = client::send(method, args, &mut stream)
-        .and_then(|_bytes_written| client::receive(&mut stream, Arc::new(response_handler)));
+        .and_then(|_bytes_written| client::receive(&mut stream, response_handler));
 
     assert!(true);
 }


### PR DESCRIPTION
This turns `response_handler` into anything that implements `FnMut`.  It also removes the wrapping `Arc`.

Test run from a SmartOS zone:
```
root - rustdev ~/src/rust-fast (git:master) # cargo test
    Finished dev [unoptimized + debuginfo] target(s) in 6.71s
     Running target/debug/deps/rust_fast-ee9a2d978f0bc60d

running 2 tests
test protocol::test::prop_fast_message_roundtrip ... ok
test protocol::test::prop_fast_message_bundling ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/client_server_test-4347eff018547fe8

running 1 test
Apr 04 14:13:33.374 INFO listening for fast requests, address: 127.0.0.1:56655, build-id: 0.1.0
Apr 04 14:13:33.424 DEBG processing fast message, build-id: 0.1.0
Apr 04 14:13:33.424 DEBG handling echo function request, build-id: 0.1.0
Apr 04 14:13:33.424 DEBG generated response, build-id: 0.1.0
test client_server_comms ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

Apr 04 14:13:33.424 DEBG transmitted response to client, build-id: 0.1.0
   Doc-tests rust_fast

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

I left this as three separate commits but feel free to squash them down into one if you decide to merge this.