### PR TITLE
Handle decoding multiple messages in a buffer

### DIFF
--- a/examples/fastserve.rs
+++ b/examples/fastserve.rs
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 use std::env;
 use std::io::{Error, ErrorKind};
 use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::prelude::*;
@@ -149,7 +149,8 @@ fn main() {
             .incoming()
             .map_err(move |e| error!(&err_log, "failed to accept socket"; "err" => %e))
             .for_each(move |socket| {
-                server::process(socket, Arc::new(msg_handler), &process_log);
+                let task = server::make_task(socket, msg_handler, &process_log);
+                tokio::spawn(task);
                 Ok(())
             })
     });


### PR DESCRIPTION
Fix a bug where only one message per buffer was ever decoded. Also refactor the
server handling to avoid the need for an Arc on the response handling function.
