### PR TITLE
Relax server response handler constraints

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -18,7 +18,7 @@ pub fn make_task<F>(
     log: &Logger,
 ) -> impl Future<Item = (), Error = ()> + Send
 where
-    F: FnMut(&FastMessage, &Logger) -> Result<Vec<FastMessage>, Error> + Send + Sync,
+    F: FnMut(&FastMessage, &Logger) -> Result<Vec<FastMessage>, Error> + Send,
 {
     let (tx, rx) = FastRpc.framed(socket).split();
     let rx_log = log.clone();


### PR DESCRIPTION
The server response handler provided to the make_task function can get away
without requiring the Sync constraint. This provides more flexibility for users
of the rust-fast library.