### PR TITLE
Update fast protocol version to 2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## not yet released
+
+Update fast protocol version to 2 to be compatible with node-fast version 3.0.0
+servers.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "rust_fast"
 version = "0.1.1"
 authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
+description = """
+streaming JSON RPC over TCP
+"""
+repository = "https://github.com/joyent/rust-fast"
+keywords = ["protocol","joyent"]
+readme = "./README.md"
+license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Joyent, Inc.
+// Copyright 2020 Joyent, Inc.
 
 //! This module contains the types and functions used to encode and decode Fast
 //! messages. The contents of this module are not needed for normal client or
@@ -29,8 +29,8 @@ const FP_OFF_DATA: usize = 0xf;
 /// The size of a Fast message header
 pub const FP_HEADER_SZ: usize = FP_OFF_DATA;
 
-const FP_VERSION_1: u8 = 0x1;
-const FP_VERSION_CURRENT: u8 = FP_VERSION_1;
+const FP_VERSION_2: u8 = 0x2;
+const FP_VERSION_CURRENT: u8 = FP_VERSION_2;
 
 /// A data type representing a Fast message id that can safely be shard between
 /// threads. The `next` associated function retrieves the next id value and


### PR DESCRIPTION
This change corresponds to the version change with node-fast version 3.0.0. The
change was made to work around a CRC library incompatibility with node-fast and
this ensures that programs using rust-fast continue to be compatible with
node-fast programs.